### PR TITLE
Fix paths in 'test the build' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ H2/push-compatible servers or to clients that do not support H2/Push.
 This command serves the minified version of the app in an unbundled state, as it would
 be served by a push-compatible server:
 
-    polymer serve src/unbundled
+    polymer serve build/unbundled
 
 This command serves the minified version of the app generated using fragment bundling:
 
-    polymer serve src/bundled
+    polymer serve build/bundled
 
 ### Extend
 


### PR DESCRIPTION
Testing the build should use `build` path, not `src`
