### PR TITLE
Fix bug in polyfill init

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // polyfill web components
         var e = document.createElement('script');
         e.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
-        document.body.appendChild(e);
+        document.head.appendChild(e);
       }
     })();
 


### PR DESCRIPTION
The init code attempts to append the WebComponents polyfill to the body while in the header, while the body element is still null.
