### PR TITLE
Close the drawer when selecting a view. Fix #20.

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -75,9 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <app-drawer>
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="view1" href="/view1">View One</a>
-          <a name="view2" href="/view2">View Two</a>
-          <a name="view3" href="/view3">View Three</a>
+          <a name="view1" href="/view1" drawer-toggle>View One</a>
+          <a name="view2" href="/view2" drawer-toggle>View Two</a>
+          <a name="view3" href="/view3" drawer-toggle>View Three</a>
         </iron-selector>
       </app-drawer>
 


### PR DESCRIPTION
This only solved the problem for the mobile case, when the drawer is initially hidden. When viewing the page on desktop, clicking on any menu item will permanently hide the drawer.
