### PR TITLE
Change title to main-title

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -87,7 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <app-header condenses reveals effects="waterfall">
           <app-toolbar>
             <paper-icon-button icon="menu" drawer-toggle></paper-icon-button>
-            <div title>My App</div>
+            <div main-title>My App</div>
           </app-toolbar>
         </app-header>
 


### PR DESCRIPTION
I believe that the attribute name was changed from `title` to `main-title` in the new app-toolbar as shown in this commit https://github.com/PolymerElements/app-layout/commit/a9ba663cacedaaff8f205923b8db987d27fb143b.
